### PR TITLE
Avoid mixed-content errors if loaded over HTTPS

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
 <meta charset="utf-8" />
 <title>Animatable: One property, two values, endless possibilities</title>
 <link href="style.css" rel="stylesheet" />
-<script src="http://leaverou.github.com/prefixfree/prefixfree.min.js"></script>
+<script src="//leaverou.github.com/prefixfree/prefixfree.min.js"></script>
 </head>
 <body>
 
@@ -88,7 +88,7 @@
 <a href="https://twitter.com/share" class="twitter-share-button" data-count="vertical" data-via="LeaVerou">Tweet</a>
 <script src="https://platform.twitter.com/widgets.js"></script>
 
-<script src="http://www.google-analytics.com/ga.js"></script> 
+<script src="//www.google-analytics.com/ga.js"></script> 
 <script> 
 try {
 var pageTracker = _gat._getTracker("UA-597483-5");


### PR DESCRIPTION
[PR self to my fork's gh-pages to make https://cben.github.io/animatable/ demo work] 

GH Pages got (unofficial) HTTPS support since April 2014:
https://konklone.com/post/github-pages-now-sorta-supports-https-so-use-it
and at least HTTPS Everywhere users will load https://leaverou.github.io/animatable/ and scratch their heads why nothing animates.

Left the main JS reference protocol-relative so http doesn't entirely break for non-SNI browsers (IE on XP, stock browser on Android 2.x) or in case Github's https support breaks.
AFAIK google analytics URL works but might cause security popup on IE6.
